### PR TITLE
Retain format element when text becomes empty

### DIFF
--- a/src/blot/abstract/parent.ts
+++ b/src/blot/abstract/parent.ts
@@ -81,8 +81,8 @@ class ParentBlot extends ShadowBlot implements Parent {
       });
   }
 
-  public deleteAt(index: number, length: number): void {
-    if (index === 0 && length === this.length()) {
+  public deleteAt(index: number, length: number, avoidRemove: boolean = false): void {
+    if (index === 0 && length === this.length() && !avoidRemove) {
       return this.remove();
     }
     this.children.forEachAt(index, length, (child, offset, childLength) => {

--- a/src/blot/inline.ts
+++ b/src/blot/inline.ts
@@ -54,6 +54,11 @@ class InlineBlot extends ParentBlot implements Formattable {
     this.attributes = new AttributorStore(this.domNode);
   }
 
+  public deleteAt(index: number, length: number): void {
+    const avoidRemove = this.parent.children.indexOf(this) === 0;
+    super.deleteAt(index, length, avoidRemove);
+  }
+
   public format(name: string, value: any): void {
     if (name === this.statics.blotName && !value) {
       this.children.forEach((child) => {

--- a/src/blot/text.ts
+++ b/src/blot/text.ts
@@ -50,9 +50,7 @@ class TextBlot extends LeafBlot implements Leaf {
   public optimize(context: { [key: string]: any }): void {
     super.optimize(context);
     this.text = this.statics.value(this.domNode);
-    if (this.text.length === 0) {
-      this.remove();
-    } else if (this.next instanceof TextBlot && this.next.prev === this) {
+    if (this.text.length !== 0 && this.next instanceof TextBlot && this.next.prev === this) {
       this.insertAt(this.length(), (this.next as TextBlot).value());
       this.next.remove();
     }

--- a/src/collection/linked-list.ts
+++ b/src/collection/linked-list.ts
@@ -160,7 +160,7 @@ class LinkedList<T extends LinkedNode> {
     if (length <= 0) {
       return;
     }
-    const [startNode, offset] = this.find(index);
+    const [startNode, offset] = this.find(index, true);
     let curIndex = index - offset;
     const next = this.iterator(startNode);
     let cur = next();

--- a/test/unit/inline.js
+++ b/test/unit/inline.js
@@ -45,12 +45,12 @@ describe('InlineBlot', function () {
     expect(italicBlot.domNode.outerHTML).toEqual(original);
   });
 
-  it('delete + unwrap', function () {
+  it('delete', function () {
     let node = document.createElement('p');
     node.innerHTML = '<em><strong>Test</strong></em>!';
     let container = this.scroll.create(node);
     container.deleteAt(0, 4);
-    expect(container.children.head.value()).toEqual('!');
+    expect(container.children.head instanceof ItalicBlot).toEqual(true);
   });
 
   it('formats()', function () {

--- a/test/unit/lifecycle.js
+++ b/test/unit/lifecycle.js
@@ -60,7 +60,7 @@ describe('Lifecycle', function () {
       );
     });
 
-    it('unwrap recursive', function () {
+    it('keep formats empty text', function () {
       let node = document.createElement('p');
       node.innerHTML = '<em><strong>Test</strong></em>';
       let block = this.scroll.create(node);
@@ -68,7 +68,7 @@ describe('Lifecycle', function () {
       let text = this.scroll.find(node.querySelector('strong').firstChild);
       text.deleteAt(0, 4);
       this.scroll.optimize();
-      expect(this.container.innerHTML).toEqual('');
+      expect(this.container.innerHTML).toEqual('<p><em><strong></strong></em></p>');
     });
 
     it('format merge', function () {
@@ -158,16 +158,18 @@ describe('Lifecycle', function () {
       expect(this.container.querySelector('strong').childNodes.length).toBe(1);
     });
 
-    it('remove text + recursive merge', function () {
-      let node = document.createElement('p');
-      node.innerHTML = '<em>Te</em>|<em>st</em>';
-      let block = this.scroll.create(node);
-      this.scroll.appendChild(block);
-      node.childNodes[1].data = '';
-      this.scroll.optimize();
-      expect(this.container.innerHTML).toEqual('<p><em>Test</em></p>');
-      expect(this.container.firstChild.firstChild.childNodes.length).toBe(1);
-    });
+    // NOTE: This test case is removed because this case is handled by creately / quill
+    // it('remove text + recursive merge', function () {
+    //   let node = document.createElement('p');
+    //   node.innerHTML = '<em>Te</em>|<em>st</em>';
+    //   let block = this.scroll.create(node);
+    //   this.scroll.appendChild(block);
+    //   node.childNodes[1].data = '';
+    //   debugger;
+    //   this.scroll.optimize();
+    //   expect(this.container.innerHTML).toEqual('<p><em>Test</em></p>');
+    //   expect(this.container.firstChild.firstChild.childNodes.length).toBe(1);
+    // });
 
     it('insert default child', function () {
       HeaderBlot.defaultChild = ImageBlot;

--- a/test/unit/linked-list.js
+++ b/test/unit/linked-list.js
@@ -211,8 +211,8 @@ describe('LinkedList', function () {
     it('forEachAt', function () {
       this.list.append(this.a, this.b, this.c);
       this.list.forEachAt(3, 3, this.spy.callback);
-      expect(this.spy.callback.calls.count()).toBe(1);
-      expect(this.spy.callback.calls.first().args).toEqual([this.b, 0, 3]);
+      expect(this.spy.callback.calls.count()).toBe(2);
+      expect(this.spy.callback.calls.first().args).toEqual([this.a, 3, 0]);
     });
 
     it('forEachAt zero length nodes', function () {

--- a/test/unit/parent.js
+++ b/test/unit/parent.js
@@ -25,7 +25,7 @@ describe('Parent', function () {
     });
 
     it('range', function () {
-      expect(this.blot.descendants(TextBlot, 1, 3).length).toEqual(2);
+      expect(this.blot.descendants(TextBlot, 1, 3).length).toEqual(3);
     });
 
     it('function match', function () {
@@ -37,7 +37,7 @@ describe('Parent', function () {
           1,
           3,
         ).length,
-      ).toEqual(2);
+      ).toEqual(3);
     });
   });
 


### PR DESCRIPTION
favro: [https://favro.com/organization/c9668dc39f1bd49fed254201/6a932da5a9e16600f2a20ca3?card=Cre-9406](https://favro.com/organization/c9668dc39f1bd49fed254201/6a932da5a9e16600f2a20ca3?card=Cre-9406)

**This Fix has multiple pull requests. For creately/parchment only this PR and this PR should be merged before other PRs.**

- `src / blot /text.ts` (`TextBlot` class) `optimize `function modified to keep the text node even if it is empty.
- `src / collection / linked-list.ts` (`LinkedList `class) `foreachAt `function called find with inclusive of parameter index.
- `src / blot /inline.ts` (`InlineBlot `class) added new function overriding super `deleteAt `function and check whether instance is first child of the parent and if it is passed parameter to super function to not to remove this instance even if it has no children.
- `src / blot / abstract /parent.ts` (`ParentBlot `class) added new parameter `avoidRemove `to `deleteAt `function and default is set to `false`. If the `avoidRemove` is `true `then instance will not be removed even if deleting the last character in the instance text.